### PR TITLE
WMDP-169 Add CD to the Mock API

### DIFF
--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -1,0 +1,50 @@
+# Deploy steps:
+# - Build and tag a docker release image
+# - Upload the docker image to ECR
+# - Trigger a rotation of the ECS service containers
+#
+# The underlying terraform is managed in the wic-mt-demo-project repo and references the uploaded docker image.
+
+name: Mock API Deploy
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        default_value: "test"
+        description: |
+          Choose an environment to deploy changes to.
+        type: choice
+        options:
+          - test
+          - stage
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build and Deploy Mock API
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Authenticate with AWS
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::546642427916:role/deployment-action
+          role-duration-seconds: 3600
+
+      - name: Build and Tag Image
+        run: |
+          docker build --tag 546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest ./app
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo
+          docker push 546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest
+
+      - name: Push to ECR
+        run: |
+          aws ecs update-service --cluster ${{github.event.inputs.environment || 'test' }} --service ${{github.event.inputs.environment || 'test' }}-api-ecs-service --force-new-deployment


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/WMDP-169

## Changes
* added the `deploy-mock-api` action

## Context for reviewers

> CD should:
> Build the image
> Store the image in ECR
> Run aws ecs update-service --cluster --service --force-new-deployment after we confirm the image is in ECR in order to force the update

This works in a similar manner to the CD workflow found in the [eligibility screener repo](https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/pull/67)
## Testing
The Github CLI does have an option to run workflows with the workflow_dispatch attribute manually, but this method will not work unless the workflow has been merged.
(Here's the command in case you were curious)
`gh workflow run deploy-screener.yml -f environment=test`
