### PR TITLE
WMDP-198 Patch CI workflow

### DIFF
--- a/.github/workflows/api-checks.yml
+++ b/.github/workflows/api-checks.yml
@@ -1,6 +1,8 @@
 name: Mock API Checks
 
 on:
+  #for testing purposes
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/api-checks.yml
+++ b/.github/workflows/api-checks.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Placeholder until linting is installed"
           exit 0
   security:
-    runs-on: ubutntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/api-checks.yml
+++ b/.github/workflows/api-checks.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - app/**
+  pull_request:
+    paths:
+      - app/**
 # this workflow should be updated/merged when WMDP-123. etc are merged
 jobs:
   lint:

--- a/.github/workflows/api-checks.yml
+++ b/.github/workflows/api-checks.yml
@@ -1,8 +1,6 @@
 name: Mock API Checks
 
 on:
-  #for testing purposes
-  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/WMDP-198

## Changes
*added trigger that may have caused the workflow to hang overnight

## Context for reviewers
> Yesterday two instances of the Mock API Checks jobs were triggered but never completed. One of these jobs was left in a pending state for about 17hours. 

## Testing
[successful run](https://github.com/navapbc/wic-mt-demo-project-mock-api/runs/8119859177?check_suite_focus=true)

