### PR TITLE
WMDP-209: Add run-task script to make running ECS tasks manually easier

### DIFF
--- a/app/bin/run-ecs-task/README.md
+++ b/app/bin/run-ecs-task/README.md
@@ -1,0 +1,62 @@
+# Run Task
+The `run-task.sh` is a wrapper shell script around the AWS run task command for starting ECS tasks. It helps setup and find the parameters necessary for starting an ECS task.
+
+# Setup
+This command requires you to have the [AWS CLI](https://aws.amazon.com/cli/) setup and configured locally.
+
+It also heavily uses `jq` for parsing and generating the CSV configurations.
+
+# Usage
+
+`./run-task.sh -a your.name -e test -t your-task-definition` is the most basic way to run a task.
+
+The script has the following parameters:
+* `-a` - The author running the script (eg. if your name is Bob Smith, put `-a bob.smith`)
+* `-e` - The environment you want to run the script in (eg. `-e test`)
+* `-t` - The ECS task definition you want to run (Your task definitions can be found at https://us-east-1.console.aws.amazon.com/ecs/home#/taskDefinitions , eg `-t db-migrate-up`)
+* `-s` - (Optional) - The subnets the ECS task could run in (eg. `-s '["subnet-123456789", "sg-567890654"]'`)
+    * If no subnet is specified, the script will fetch all subnets attached to the account.
+* `-g` - (Optional) - The security group IDs to attach to the ECS task (eg. `-g '["sg-1234", "sg-3456"]'`)
+    * If no security groups are specified, the `csv-handler` security group is fetched (TODO)
+
+## Template Files
+Two JSON template files exist which are used to help format the JSON configurations.
+
+### Network config
+The network config should be left as-is, as the subnet and security groups are specified as described in the usage section above.
+
+### Container overrides
+The container overrides are used for adjusting the ECS task you're running.
+
+* `name` - Specifies what ECS container to run the ECS task in (by default is `test-mock-api-container` at the moment.) 
+* `command` - (Optional) What command to run for the ECS task. **This overrides whatever the default command for a task is**. The original command will not run, and instead this command will be run, which means it is possible to use an existing ECS task to run one that hasn't been fully configured.
+    * Each separate word in the command should be an item in an array. For example, to run `poetry run db-migrate-up` you would want to specify `["poetry", "run", "db-migrate-up"]`.
+* `environment` - (Optional) Environment variable overrides to change the defaults on the container.
+
+Note that the command and environment do not change the ECS task itself, and only override the values for the run you are starting. Running the task again without any overrides will use the defaults.
+
+```json
+{
+  "containerOverrides": [
+    {
+        "name": "test-mock-api-container",
+        "command": ["poetry", "run", "db-migrate-up"],
+        "environment": [
+            {
+                "name":"LOG_FORMAT",
+                "value":"json"
+            }
+        ]
+    }
+  ]
+}
+
+```
+
+
+# TODO
+As we are building this alongside some of our infrastructure setup, not everything is 100% setup. A few TODOs we will circle back to include:
+* The subnets should be filtered to the correct VPC. Right now we only have one VPC, but if you run with multiple, you'll likely want to be able to choose the correct one (eg. a non-prod, or prod VPC which could be figured out by the environment variable)
+* The security group fetched should ideally be something more general like one for all ECS tasks (and potentially more than 1).
+* The container name is hardcoded in the container overrides. Ideally it should factor in the environment + potentially vary with the ECS task.
+* Network configuration should not have public IP addresses, however we need to reconfigure our networking to make that work.

--- a/app/bin/run-ecs-task/README.md
+++ b/app/bin/run-ecs-task/README.md
@@ -2,9 +2,11 @@
 The `run-task.sh` is a wrapper shell script around the AWS run task command for starting ECS tasks. It helps setup and find the parameters necessary for starting an ECS task.
 
 # Setup
-This command requires you to have the [AWS CLI](https://aws.amazon.com/cli/) setup and configured locally.
+This command requires you to have the [AWS CLI](https://aws.amazon.com/cli/) setup and configured locally. Make sure to [setup your AWS account credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html) before running this script. Running `aws configure` should also walk you through whatever is necessary to get connected.
 
-It also heavily uses `jq` for parsing and generating the CSV configurations.
+An easy way to validate you have the AWS CLI configured correctly is to do `aws s3 ls` which will list any S3 buckets in your account.
+
+The script also heavily uses `jq` for parsing and generating the CSV configurations, which should automatically be installed on any machine.
 
 # Usage
 
@@ -13,6 +15,8 @@ It also heavily uses `jq` for parsing and generating the CSV configurations.
 The script has the following parameters:
 * `-a` - The author running the script (eg. if your name is Bob Smith, put `-a bob.smith`)
 * `-e` - The environment you want to run the script in (eg. `-e test`)
+    * This assumes that the ECS cluster you want to run in is named exactly your environment (ie. a cluster named just `test`)
+    * This also is used to determine the ECS container to override and run with (eg. `{ENVIRONMENT}-mock-api-container`)
 * `-t` - The ECS task definition you want to run (Your task definitions can be found at https://us-east-1.console.aws.amazon.com/ecs/home#/taskDefinitions , eg `-t db-migrate-up`)
 * `-s` - (Optional) - The subnets the ECS task could run in (eg. `-s '["subnet-123456789", "sg-567890654"]'`)
     * If no subnet is specified, the script will fetch all subnets attached to the account.
@@ -23,40 +27,67 @@ The script has the following parameters:
 Two JSON template files exist which are used to help format the JSON configurations.
 
 ### Network config
-The network config should be left as-is, as the subnet and security groups are specified as described in the usage section above.
+The [network config template](./network_config.json.tpl) should be left as-is, as the subnet and security groups are specified as described in the usage section above, and values added to the file will be overriden by the script.
 
 ### Container overrides
-The container overrides are used for adjusting the ECS task you're running.
+The [container override template](./container_overrides.json.tpl) is used for adjusting configurations of the ECS task you're running.
 
-* `name` - Specifies what ECS container to run the ECS task in (by default is `test-mock-api-container` at the moment.) 
+* `name` - Specifies what ECS container to run the ECS task in - overriden automatically to `{ENVIRONMENT}-mock-api-container` at the moment.
 * `command` - (Optional) What command to run for the ECS task. **This overrides whatever the default command for a task is**. The original command will not run, and instead this command will be run, which means it is possible to use an existing ECS task to run one that hasn't been fully configured.
     * Each separate word in the command should be an item in an array. For example, to run `poetry run db-migrate-up` you would want to specify `["poetry", "run", "db-migrate-up"]`.
 * `environment` - (Optional) Environment variable overrides to change the defaults on the container.
 
 Note that the command and environment do not change the ECS task itself, and only override the values for the run you are starting. Running the task again without any overrides will use the defaults.
 
+See the [CLI documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecs/run-task.html) for further details on container overrides you can specify.
+
+You cannot override sensitive environment variables pulled from parameter store as those are only able to be set when the ECS container is created.
+# Example
+
+## Basic
+You have an ECS task definition named `example-ecs-task-definition` that you want to run a script in. You want to run this script in your `test` environment, and want to run the ECS task without any overrides (ie. leaving the command, environment variables, subnets, and security groups alone).
+
+You just need to run `./run-task.sh -a your.name -e test -t example-ecs-task-definition` which should startup your task with all the normal defaults.
+
+## Override Example
+You have an ECS task definition named `example-ecs-task-definition` that you want to run a script in. You want to run this script in your `test` environment, but want to override everything possible and set them instead as:
+* The command run by the ECS task -> `poetry run db-migrate-up`
+* The environment variables of the ECS task -> `LOG_FORMAT=json`
+* The subnets -> `subnet-1234, subnet-4567`
+* The security groups -> `sg-abcd`
+
+Subnets and security groups need to be specified as command line parameters like so:
+`./run-task.sh -a your.name -e test -t example-ecs-task-definition -s '["subnet-1234", "sg-4567"]' -g '["sg-abcd"]'`
+Note that the formatting must match this format exactly with `'` quotes containing the array, and `"` quotes surrounding the names of the names of the subnets and security groups.
+
+To override the command and environment variables, you'll need to open the [container_overrides.json.tpl](./container_overrides.json.tpl) file and edit it. The `name` field should be left alone as the script will overwrite any values, but you can set the command you want to run by adding command to override JSON. Do not attempt to specify a command as a single string with spaces as it will fail to run, each "word" of the command must be a separate string in the array.
+
+Additionally, you can set as many environment variable overrides as you want by specifying the name and value you want for each one. For this example, your file would now look like:
+
 ```json
 {
   "containerOverrides": [
     {
-        "name": "test-mock-api-container",
+        "name": "PLACEHOLDER OVERRIDEN BY SCRIPT  - SEE README FOR HOW THIS GETS SET",
         "command": ["poetry", "run", "db-migrate-up"],
         "environment": [
             {
                 "name":"LOG_FORMAT",
                 "value":"json"
+            },
+            {
+                "name":"OUTPUT_PATH",
+                "value":"s3://bucket/path/to"
             }
         ]
     }
   ]
 }
-
 ```
-
 
 # TODO
 As we are building this alongside some of our infrastructure setup, not everything is 100% setup. A few TODOs we will circle back to include:
 * The subnets should be filtered to the correct VPC. Right now we only have one VPC, but if you run with multiple, you'll likely want to be able to choose the correct one (eg. a non-prod, or prod VPC which could be figured out by the environment variable)
 * The security group fetched should ideally be something more general like one for all ECS tasks (and potentially more than 1).
-* The container name is hardcoded in the container overrides. Ideally it should factor in the environment + potentially vary with the ECS task.
+* The container name is hardcoded to be `{ENV_NAME}-mock-api-container`. Ideally it should factory in the ECS task and choose the right container.
 * Network configuration should not have public IP addresses, however we need to reconfigure our networking to make that work.

--- a/app/bin/run-ecs-task/container_overrides.json.tpl
+++ b/app/bin/run-ecs-task/container_overrides.json.tpl
@@ -1,7 +1,7 @@
 {
   "containerOverrides": [
     {
-        "name": "test-mock-api-container",
+        "name": "PLACEHOLDER OVERRIDEN BY SCRIPT  - SEE README FOR HOW THIS GETS SET",
         "environment": [
             {
                 "name":"LOG_FORMAT",

--- a/app/bin/run-ecs-task/container_overrides.json.tpl
+++ b/app/bin/run-ecs-task/container_overrides.json.tpl
@@ -1,0 +1,13 @@
+{
+  "containerOverrides": [
+    {
+        "name": "test-mock-api-container",
+        "environment": [
+            {
+                "name":"LOG_FORMAT",
+                "value":"json"
+            }
+        ]
+    }
+  ]
+}

--- a/app/bin/run-ecs-task/network_config.json.tpl
+++ b/app/bin/run-ecs-task/network_config.json.tpl
@@ -1,7 +1,7 @@
 {
   "awsvpcConfiguration": {
     "assignPublicIp": "ENABLED",
-    "securityGroups": [],
-    "subnets": []
+    "securityGroups": ["PLACEHOLDER OVERRIDEN BY SCRIPT - SEE README FOR HOW THIS GETS SET"],
+    "subnets": ["PLACEHOLDER OVERRIDEN BY SCRIPT  - SEE README FOR HOW THIS GETS SET"]
   }
 }

--- a/app/bin/run-ecs-task/network_config.json.tpl
+++ b/app/bin/run-ecs-task/network_config.json.tpl
@@ -1,0 +1,7 @@
+{
+  "awsvpcConfiguration": {
+    "assignPublicIp": "ENABLED",
+    "securityGroups": [],
+    "subnets": []
+  }
+}

--- a/app/bin/run-ecs-task/run-task.sh
+++ b/app/bin/run-ecs-task/run-task.sh
@@ -85,8 +85,12 @@ NETWORK_CONFIG=$(jq \
      .awsvpcConfiguration.subnets=$SUBNETS' \
     $DIR/network_config.json.tpl)
 
-# Use the container override file as-is
-OVERRIDES=$(jq . $DIR/container_overrides.json.tpl)
+# Set the name of the container
+CONTAINER_NAME="$ENV_NAME-mock-api-container"
+OVERRIDES=$(jq \
+    --arg CONTAINER_NAME "$CONTAINER_NAME" \
+    '.containerOverrides[0].name=$CONTAINER_NAME' \
+    $DIR/container_overrides.json.tpl)
 
 # Build the ECS run-task command
 AWS_ARGS=("--region=us-east-1"

--- a/app/bin/run-ecs-task/run-task.sh
+++ b/app/bin/run-ecs-task/run-task.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Run an ECS task using supplied configurations.
+#
+# See README.md for details on how this script works.
+set -o errexit -o pipefail
+
+DIR=$(dirname "${BASH_SOURCE[0]}")
+
+usage() {
+    echo "Usage: ./run-task.sh -a YOUR.NAME -e ENV_NAME -t TASK_NAME"
+    echo "ex: ./run-task.sh -a bob.smith -e test -t db-migrate-up"
+    echo "See the README.md for further details"
+    exit 1
+}
+
+# This parses CLI arguments mapping the letter params to variables
+# Note that if you want to add more params, you need to add the letter
+# to the string next to getopts below
+while getopts ":a:e:t:s:g:" opt; do
+    case $opt in
+        a)
+            AUTHOR="$OPTARG"
+            ;;
+        e)
+            ENV_NAME="$OPTARG"
+            ;;
+        t)
+            TASK_NAME="$OPTARG"
+            ;;
+        s)
+            SUBNETS="$OPTARG"
+            ;;
+        g)
+            SECURITY_GROUPS="$OPTARG"
+            ;;
+        \?)
+            echo "Invalid option -$OPTARG"
+            exit 1
+            ;;
+    esac
+
+    # Error if an argument has no parameter
+    case $OPTARG in
+        -*) 
+            echo "Option $opt needs a valid argument"
+            exit 1
+            ;;
+    esac
+done
+
+# If the required environment variables are missing, print the usage info and error.
+if [ -z "$ENV_NAME" ] || [ -z "$TASK_NAME" ] || [ -z "$AUTHOR" ]; then
+  usage
+fi
+
+# If no security groups were specified, fetch them from AWS. The response is formatted as
+# {
+#   "SecurityGroups": [
+#       {"GroupName": "csv-handler", GroupId: "sg-123456789", ...}  
+# ]}
+if [ -z "$SECURITY_GROUPS" ]; then
+    # The jq command grabs all returned security group IDs and formats it into a JSON array
+    SECURITY_GROUPS=$(aws ec2 describe-security-groups --group-names csv-handler | jq -r --compact-output "[.SecurityGroups[].GroupId]")
+fi
+
+# If no subnets specified, fetch them from AWS. The response is formatted as
+# {
+#   "Subnets": [
+#   {"SubnetId": "subnet-012345abc6789", ...},
+#   {"SubnetId": "subnet-abcdef123ghij", ...}
+# ]}
+if [ -z "$SUBNETS" ]; then
+    # TODO - potentially add a VPC to filter too
+    # The jq command grabs all returned subnet IDs and formats it into a JSON array
+    SUBNETS=$(aws ec2 describe-subnets | jq -r --compact-output "[.Subnets[].SubnetId]")
+fi
+
+# Using the network config template, populate it with
+# either the supplied security group and subnet values
+# or the ones we fetched from AWS.
+NETWORK_CONFIG=$(jq \
+    --argjson SECURITY_GROUPS "$SECURITY_GROUPS" \
+    --argjson SUBNETS "$SUBNETS" \
+    '.awsvpcConfiguration.securityGroups=$SECURITY_GROUPS |
+     .awsvpcConfiguration.subnets=$SUBNETS' \
+    $DIR/network_config.json.tpl)
+
+# Use the container override file as-is
+OVERRIDES=$(jq . $DIR/container_overrides.json.tpl)
+
+# Build the ECS run-task command
+AWS_ARGS=("--region=us-east-1"
+    ecs run-task
+    "--cluster=$ENV_NAME"
+    "--started-by=$AUTHOR"
+    "--task-definition=$TASK_NAME"
+    "--launch-type=FARGATE"
+    "--platform-version=1.4.0"
+    --network-configuration "$NETWORK_CONFIG"
+    --overrides "$OVERRIDES"
+    )
+
+# Print out the arguments
+printf " ... %s" "${AWS_ARGS[@]}"
+
+# Run the ECS task
+RUN_TASK=$(aws "${AWS_ARGS[@]}")
+echo "Started task:"
+echo "$RUN_TASK" | jq .
+
+TASK_ARN=$(echo $RUN_TASK | jq '.tasks[0].taskArn' | sed -e 's/^"//' -e 's/"$//')
+
+# Wait for the ECS task to complete
+# Note this will auto-timeout after 600 seconds
+# https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecs/wait/tasks-stopped.html
+aws ecs wait tasks-stopped --region us-east-1 --cluster $ENV_NAME --tasks $TASK_ARN
+
+# Get the exit code
+TASK_STATUS=$(aws ecs describe-tasks --cluster $ENV_NAME --task $TASK_ARN | jq -r '.tasks[]')
+EXIT_CODE=$(echo $TASK_STATUS | jq '.containers[].exitCode')
+
+if [ "$EXIT_CODE" == "null" ]; then
+  STOPPED_REASON=$(echo "$TASK_STATUS" | jq '.stoppedReason')
+  echo "ECS task failed to start:" >&2
+  echo "$STOPPED_REASON" >&2
+  exit 1
+fi
+
+for CONTAINER_EXIT_CODE in $EXIT_CODE
+do
+  if [ "$CONTAINER_EXIT_CODE" -ne 0 ]; then
+    echo "ECS task ran into an error (exit codes $EXIT_CODE). Please check cloudwatch logs." >&2
+    exit 1
+  fi
+done
+
+echo "ECS task completed successfully."
+exit 0


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/WMDP-209

## Changes
Adds the `run-task.sh` script which is a wrapper around the `aws ecs run-task ..` CLI command which helps setup a lot of the configurations.

## Context for reviewers
There are a lot of things needed to run an ECS task, most notably:
* The task you want to run
* The subnet & security groups you want to use
* Who is running the task
* What container to run the task in
* What environment you are running in

Some of those like the task and environment should be manual each time, but things like the subnet and security group should ideally be pretty automated with the ability to override them, which is what this script does.

The most complex bit of this is probably the bash script commands run. Most notably the `jq` command which is used to parse and process values into JSON formatted data using a mixture of CLI and template files. Happy to add more examples of exactly how that works if the existing explanation isn't perfect.

Note that because we're still building out some of the infra, a few things are more hardcoded than would be ideal, but I've created a TODO in the readme to help keep aware of those.

## Testing
`./bin/run-ecs-task/run-task.sh -a your.name -e test -t test-csv-handler-definition` will startup the ECS task and run the CSV generation script.

[Cloudwatch Logs](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/mock-api/log-events/csv-handler$252Ftest-mock-api-container$252F65f3d208a91349a5addff9e8b55aa388) for an example run - although by default it creates the CSV file locally so it disappears after the run finishes.

I've also run this same command with the `command` field overriden in the container overrides to be `["poetry", "run", "db-migrate-up"]` in order to do the DB migrations.