### PR TITLE
WMDP-214 - Automatically add tags during github action for deploys

### DIFF
--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{github.event.inputs.environment || 'test' }}
-          message: "${{github.ref_name}}\nTag created in workflow\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          message: "from branch ${{github.ref_name}}\nTag created in workflow:\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           force_push_tag: true

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{github.event.inputs.environment || 'test' }}
-          message: "Tag created in\n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          message: "\nTag created in workflow\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           force_push_tag: true

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -34,5 +34,5 @@ jobs:
         # Running `git push --tags` may not be necessary, but we should test this. We want to be able to view tags that github creates by going to https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/tags
         # Not sure if we are able to do a `git push --tags` from inside the container job thing
         run: |
-          git tag -a ${{github.event.inputs.environment || 'test' }} -m TODO dummy message
+          git tag -a ${{github.event.inputs.environment || 'test' }} -m "TODO dummy message"
           git push --tags

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -56,6 +56,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      # https://github.com/rickstaa/action-create-tag
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{github.event.inputs.environment || 'test' }}

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - uses: actions/checkout@v2
       - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -49,7 +50,7 @@ jobs:
           aws ecs update-service --cluster ${{github.event.inputs.environment || 'test' }} --service ${{github.event.inputs.environment || 'test' }}-api-ecs-service --force-new-deployment
 
   create-tag:
-    name: Create a github tag
+    needs: [build]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -51,6 +51,8 @@ jobs:
   create-tag:
     name: Create a github tag
     runs-on: ubuntu-latest
+
+    steps:
       - uses: actions/checkout@v2
       - uses: rickstaa/action-create-tag@v1
         with:

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{github.event.inputs.environment || 'test' }}
-          message: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          message: "back to testing another msg"
           force_push_tag: true

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -32,4 +32,5 @@ jobs:
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{github.event.inputs.environment || 'test' }}
-          message: "TODO dummy message"
+          message: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          force_push_tag: true

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -2,6 +2,7 @@
 # - Build and tag a docker release image
 # - Upload the docker image to ECR
 # - Trigger a rotation of the ECS service containers
+# - Automatically tag the branch with the environment name
 #
 # The underlying terraform is managed in the wic-mt-demo-project repo and references the uploaded docker image.
 

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{github.event.inputs.environment || 'test' }}
-          message: "Tag created in ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          message: "Tag created in\n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           force_push_tag: true

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{github.event.inputs.environment || 'test' }}
-          message: "back to testing another msg"
+          message: "Tag created in ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           force_push_tag: true

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{github.event.inputs.environment || 'test' }}
-          message: "\nTag created in workflow\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          message: "${GITHUB_REF##*/}\nTag created in workflow\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           force_push_tag: true

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -51,6 +51,7 @@ jobs:
 
   create-tag:
     needs: [build]
+    name: Create Github Tag
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -30,21 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Authenticate with AWS
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: us-east-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: arn:aws:iam::546642427916:role/deployment-action
-          role-duration-seconds: 3600
-
-      - name: Build and Tag Image
+      - name: Tag commit
+        # Running `git push --tags` may not be necessary, but we should test this. We want to be able to view tags that github creates by going to https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/tags
+        # Not sure if we are able to do a `git push --tags` from inside the container job thing
         run: |
-          docker build --tag 546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest ./app
-          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo
-          docker push 546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest
-
-      - name: Push to ECR
-        run: |
-          aws ecs update-service --cluster ${{github.event.inputs.environment || 'test' }} --service ${{github.event.inputs.environment || 'test' }}-api-ecs-service --force-new-deployment
+          git tag -a ${{github.event.inputs.environment || 'test' }} -m TODO dummy message
+          git push --tags

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -29,10 +29,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Tag commit
-        # Running `git push --tags` may not be necessary, but we should test this. We want to be able to view tags that github creates by going to https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/tags
-        # Not sure if we are able to do a `git push --tags` from inside the container job thing
-        run: |
-          git tag -a ${{github.event.inputs.environment || 'test' }} -m "TODO dummy message"
-          git push --tags
+      - uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{github.event.inputs.environment || 'test' }}
+          message: "TODO dummy message"

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{github.event.inputs.environment || 'test' }}
-          message: "${GITHUB_REF##*/}\nTag created in workflow\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          message: "${{github.ref_name/}}\nTag created in workflow\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           force_push_tag: true

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -59,6 +59,6 @@ jobs:
       # https://github.com/rickstaa/action-create-tag
       - uses: rickstaa/action-create-tag@v1
         with:
-          tag: ${{github.event.inputs.environment || 'test' }}
+          tag: "deployed/${{github.event.inputs.environment || 'test' }}"
           message: "from branch ${{github.ref_name}}\nTag created in workflow:\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           force_push_tag: true

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -27,8 +27,30 @@ jobs:
   build:
     name: Build and Deploy Mock API
     runs-on: ubuntu-latest
-
+    
     steps:
+      - name: Authenticate with AWS
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::546642427916:role/deployment-action
+          role-duration-seconds: 3600
+
+      - name: Build and Tag Image
+        run: |
+          docker build --tag 546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest-${{github.event.inputs.environment || 'test' }} ./app
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo
+          docker push 546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest-${{github.event.inputs.environment || 'test' }}
+
+      - name: Push to ECR
+        run: |
+          aws ecs update-service --cluster ${{github.event.inputs.environment || 'test' }} --service ${{github.event.inputs.environment || 'test' }}-api-ecs-service --force-new-deployment
+
+  create-tag:
+    name: Create a github tag
+    runs-on: ubuntu-latest
       - uses: actions/checkout@v2
       - uses: rickstaa/action-create-tag@v1
         with:

--- a/.github/workflows/deploy-mock-api.yml
+++ b/.github/workflows/deploy-mock-api.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{github.event.inputs.environment || 'test' }}
-          message: "${{github.ref_name/}}\nTag created in workflow\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          message: "${{github.ref_name}}\nTag created in workflow\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           force_push_tag: true


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/WMDP-214

## Changes
Automatically appends a tag with a message during the deployment github action which can either be manually triggered or triggers automatically when a merge to main occurs.

## Context for reviewers
Rather than manually do the `git tag ...` commands, I found an action that handles it as there are a few minor additions in terms of authenticating with github necessary that it automatically takes care of (See: https://github.com/rickstaa/action-create-tag/blob/main/entrypoint.sh ).

The most annoying thing is how the message on a tag gets displayed on the tag page. The message goes in the title as `<tag name>: <message>` and if the message is too long it spills over into the plain text below. This makes formatting a bit of a pain, but I found adding `\n` to the message forces those out of the title at least. So, the first "line" always will go in the title. See testing section below for an example.

Happy to adjust the message that displays in the tag page. The timestamp + person who triggered it is automatically on that page, so left those details out.

## Testing
You can trigger this github action by going to https://github.com/navapbc/wic-mt-demo-project-mock-api/actions/workflows/deploy-mock-api.yml and selecting the github workflow in the top-right:
![Screen Shot 2022-09-20 at 11 52 00 AM](https://user-images.githubusercontent.com/46358556/191307748-4026584a-b491-4dd4-a9e5-36961fc80c06.png)

You'll need to change the branch to the one on this PR to trigger it.

If you go to the tag page ( https://github.com/navapbc/wic-mt-demo-project-mock-api/releases/tag/test ) you can find the tag that was updated.

![Screen Shot 2022-09-20 at 12 02 05 PM](https://user-images.githubusercontent.com/46358556/191309087-bce648a5-c508-49bf-b04e-7525af9656ad.png)

