### PR TITLE
Upgrade psycopg2 from 2.9.3 to 2.9.5.

### DIFF
--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -582,7 +582,7 @@ dev = ["tox", "pre-commit"]
 
 [[package]]
 name = "psycopg2-binary"
-version = "2.9.3"
+version = "2.9.5"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
 category = "main"
 optional = false


### PR DESCRIPTION
## Ticket

N/A

## Changes
> What was added, updated, or removed in this PR.

- Upgraded [psycopg2](https://www.psycopg.org) to latest version of 2.x

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

[From @aplybeah](https://nava.slack.com/archives/C03CGSMQ0JV/p1666723438456169):
> Two of the most recent runs of the mock API CD are failing with pg_config executable not found. As far as I can see the poetry.lock and pyproject.toml have not changed (nor have any of the changes I made should affect that)
[First attempt](https://github.com/navapbc/wic-mt-demo-project-mock-api/actions/runs/3314649650/jobs/5474210036) of this run built everything successfully and failed with an expected error (not enough IAM permissions). However, subsequent runs ([example](https://github.com/navapbc/wic-mt-demo-project-mock-api/actions/runs/3314649650)) including on [main](https://github.com/navapbc/wic-mt-demo-project-mock-api/actions/runs/3321419801/jobs/5489040965) fail in the same way

Traced the issue to the `psycopg2` library, as the docker image build was also failing for me locally:

```
> #0 46.26   EnvCommandError
#0 46.26
#0 46.26   Command ['/root/.cache/pypoetry/virtualenvs/wic-mock-api-o9msT97p-py3.11/bin/python', '-m', 'pip', 'install', '--use-pep517', '--disable-pip-version-check', '--prefix', '/root/.cache/pypoetry/virtualenvs/wic-mock-api-o9msT97p-py3.11', '--no-deps', '/root/.cache/pypoetry/artifacts/e5/e3/eb/957d6fa840cf649bc27ef3e851e6e2b7fbe0f858b2761ad2b1d601fe45/psycopg2-binary-2.9.3.tar.gz'] errored with the following return code 1, and output:
```

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Run `docker-compose up -d --build` on your local development and you should see no error.