### PR TITLE
[Post-Demo] Migrate Terraform code from project repo 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 
 # IDE-specific files
 .vscode/*
+
+# Local .terraform metadata
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*

--- a/infra/mock_api/cloudwatch.tf
+++ b/infra/mock_api/cloudwatch.tf
@@ -1,0 +1,7 @@
+# ----------------------------------------------
+# Mock API
+# ----------------------------------------------
+resource "aws_cloudwatch_log_group" "mock_api" {
+  name              = "mock-api"
+  retention_in_days = 90
+}

--- a/infra/mock_api/constants/outputs.tf
+++ b/infra/mock_api/constants/outputs.tf
@@ -1,0 +1,13 @@
+output "api_tags" {
+
+  value = {
+    project    = "mock-api"
+    owner      = "wic-mt-demo"
+    repository = "https://github.com/navapbc/wic-mt-demo-project-mock-api"
+  }
+}
+
+output "vpc_id" {
+  value       = "vpc-032e680f92b88bb68"
+  description = "Default VPC provided by AWS"
+}

--- a/infra/mock_api/ecr.tf
+++ b/infra/mock_api/ecr.tf
@@ -1,0 +1,4 @@
+resource "aws_ecr_repository" "mock-api-repository" {
+  name                 = "mock-api-repo"
+  image_tag_mutability = "MUTABLE"
+}

--- a/infra/mock_api/environments/prod/main.tf
+++ b/infra/mock_api/environments/prod/main.tf
@@ -1,0 +1,27 @@
+locals {
+  environment_name = "prod"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "wic-mt"
+}
+# s3 backend moved so that terraform won't ignore it
+
+terraform {
+  required_version = "1.2.0"
+
+  backend "s3" {
+    bucket         = "wic-mt-tf-state"
+    key            = "terraform/mock_api/prod.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "wic_terraform_locks"
+    profile        = "wic-mt" # may need to rethink this; no profile defaults to env variables
+  }
+}
+
+module "template" {
+  source           = "../../template"
+  environment_name = local.environment_name
+}

--- a/infra/mock_api/environments/stage/main.tf
+++ b/infra/mock_api/environments/stage/main.tf
@@ -1,0 +1,27 @@
+locals {
+  environment_name = "stage"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "wic-mt"
+}
+# s3 backend moved so that terraform won't ignore it
+
+terraform {
+  required_version = "1.2.0"
+
+  backend "s3" {
+    bucket         = "wic-mt-tf-state"
+    key            = "terraform/mock_api/stage.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "wic_terraform_locks"
+    profile        = "wic-mt" # may need to rethink this; no profile defaults to env variables
+  }
+}
+
+module "template" {
+  source           = "../../template"
+  environment_name = local.environment_name
+}

--- a/infra/mock_api/environments/test/.terraform.lock.hcl
+++ b/infra/mock_api/environments/test/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.16.0"
+  constraints = "~> 4.16.0"
+  hashes = [
+    "h1:jmf/sbrsF1//4DG3QdPzbjCNsPUCp66g7ysuyj8QECc=",
+    "zh:0aa204fead7c431796386cc9e73ccda9a185f37e46d4b6475ff3f56ad4f15101",
+    "zh:130396f5da1650f4d6949e67ec44e0f408a529b7f76c48701a7bf21ba6949bbc",
+    "zh:271bfa95bc1332676a81d3f01ba1b5a188abf26df475ca9f25972c68935b6ee9",
+    "zh:51bc600c6c00292c6cb00ca460c555fb2cafd11d5fe9c5dc7d4ce62ec71874f8",
+    "zh:6ece49ba67e484777e1588a08b043c186aa896b5189b0a5056eb7838c566f63e",
+    "zh:994402e0973b12f2266f2d3ad00f000b2e2f3ee6961631aeab32688c0c4e07fd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e9ef874b11dfb1960aa18e1254ee430142cb583f721a2ed44b608ddf652db57",
+    "zh:bb1755cd1dd39e0caf98efb1ccb5b03323f77ba13b3f5531bfe28aded7750db0",
+    "zh:e5e73ddc1e3d0c0311be90176152c07f0d27af377a95baab72c6f00622461f46",
+    "zh:e7fd8313107ab7f63297b8440b0ccf08a7b56a329ae110ad9b6ef51959939a20",
+    "zh:f095a3f10331b3a91527822a2a881a6714c2e40ee20a14b3c127340c540e37e5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.4.3"
+  hashes = [
+    "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+  ]
+}

--- a/infra/mock_api/environments/test/main.tf
+++ b/infra/mock_api/environments/test/main.tf
@@ -1,0 +1,25 @@
+locals {
+  environment_name = "test"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "wic-mt"
+}
+
+terraform {
+  required_version = "1.2.0"
+
+  backend "s3" {
+    bucket         = "wic-mt-tf-state"
+    key            = "terraform/mock_api/test.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "wic_terraform_locks"
+    profile        = "wic-mt" # may need to rethink this; no profile defaults to env variables
+  }
+}
+module "template" {
+  source           = "../../template"
+  environment_name = local.environment_name
+}

--- a/infra/mock_api/iam.tf
+++ b/infra/mock_api/iam.tf
@@ -1,0 +1,17 @@
+# add ecr perms (push)
+data "aws_iam_policy_document" "deploy_action" {
+  statement {
+    sid     = "WICUpdateECR"
+    actions = ["ecs:UpdateCluster", "ecs:UpdateService", "ecs:DescribeClusters", "ecs:DescribeServices", "ecr:*"]
+    resources = [
+      "arn:aws:ecs:us-east-1:546642427916:service/${var.environment_name}/*",
+      "arn:aws:ecs:us-east-1:546642427916:cluster/${var.environment_name}",
+      aws_ecr_repository.mock-api-repository.arn
+    ]
+  }
+  statement {
+    sid       = "WICLogin"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+}

--- a/infra/mock_api/template/.terraform.lock.hcl
+++ b/infra/mock_api/template/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.16.0"
+  constraints = "~> 4.16.0"
+  hashes = [
+    "h1:jmf/sbrsF1//4DG3QdPzbjCNsPUCp66g7ysuyj8QECc=",
+    "zh:0aa204fead7c431796386cc9e73ccda9a185f37e46d4b6475ff3f56ad4f15101",
+    "zh:130396f5da1650f4d6949e67ec44e0f408a529b7f76c48701a7bf21ba6949bbc",
+    "zh:271bfa95bc1332676a81d3f01ba1b5a188abf26df475ca9f25972c68935b6ee9",
+    "zh:51bc600c6c00292c6cb00ca460c555fb2cafd11d5fe9c5dc7d4ce62ec71874f8",
+    "zh:6ece49ba67e484777e1588a08b043c186aa896b5189b0a5056eb7838c566f63e",
+    "zh:994402e0973b12f2266f2d3ad00f000b2e2f3ee6961631aeab32688c0c4e07fd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e9ef874b11dfb1960aa18e1254ee430142cb583f721a2ed44b608ddf652db57",
+    "zh:bb1755cd1dd39e0caf98efb1ccb5b03323f77ba13b3f5531bfe28aded7750db0",
+    "zh:e5e73ddc1e3d0c0311be90176152c07f0d27af377a95baab72c6f00622461f46",
+    "zh:e7fd8313107ab7f63297b8440b0ccf08a7b56a329ae110ad9b6ef51959939a20",
+    "zh:f095a3f10331b3a91527822a2a881a6714c2e40ee20a14b3c127340c540e37e5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.4.3"
+  hashes = [
+    "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+  ]
+}

--- a/infra/mock_api/template/ecs.tf
+++ b/infra/mock_api/template/ecs.tf
@@ -1,0 +1,343 @@
+locals {
+  container_name = "${var.environment_name}-mock-api-container"
+}
+# ---------------------------------------
+#
+# Load Balancing
+#
+# ---------------------------------------
+data "aws_security_group" "allow-lb-traffic" {
+  name = "screener_load_balancer_sg"
+}
+resource "aws_lb" "mock_api" {
+  name               = "${var.environment_name}-mock-api-lb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [data.aws_security_group.allow-lb-traffic.id]
+  subnets = [
+    "subnet-05b0618f4ef1a808c",
+    "subnet-06067596a1f981034",
+    "subnet-06b4ec8ff6311f69d",
+    "subnet-08d7f1f9802fd20c4",
+    "subnet-09c317466f27bb9bb",
+    "subnet-0ccc97c07aa49a0ae"
+  ] # find a way to map all the default ones here; hardcoding for now
+  ip_address_type        = "ipv4"
+  desync_mitigation_mode = "defensive"
+}
+
+resource "aws_lb_target_group" "mock_api" {
+  name        = "${var.environment_name}-mock-api-lb"
+  port        = 8080
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = module.constants.vpc_id
+  health_check {
+    enabled = true
+    port    = 8080
+    path    = "/v1/healthcheck"
+  }
+}
+
+resource "aws_lb_listener" "screener" {
+  load_balancer_arn = aws_lb.mock_api.arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.mock_api.arn
+  }
+}
+data "aws_ecr_repository" "mock-api-repository" {
+  name = "mock-api-repo"
+}
+
+data "aws_iam_policy_document" "ecr-perms" {
+  statement {
+    sid = "ECRPerms"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetLifecyclePolicy",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+}
+
+resource "aws_ecr_repository_policy" "mock-api-repo-policy" {
+  repository = data.aws_ecr_repository.mock-api-repository.name
+  policy     = data.aws_iam_policy_document.ecr-perms.json
+}
+
+
+resource "aws_ecs_cluster" "mock-api-ecs-cluster" {
+  name = var.environment_name
+}
+
+resource "aws_ecs_service" "mock-api-ecs-service" {
+  name            = "${var.environment_name}-api-ecs-service"
+  cluster         = aws_ecs_cluster.mock-api-ecs-cluster.id
+  task_definition = aws_ecs_task_definition.mock-api-ecs-task-definition.arn
+  launch_type     = "FARGATE"
+  network_configuration {
+    subnets          = ["subnet-06b4ec8ff6311f69d"]
+    assign_public_ip = true
+    security_groups  = [aws_security_group.allow-api-traffic.id]
+  }
+  desired_count = 1
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+  force_new_deployment = true
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.mock_api.arn
+    container_name   = local.container_name # from the task definition 
+    container_port   = 8080                 # from the exposed docker container on the screener
+  }
+}
+
+resource "aws_security_group" "allow-api-traffic" {
+  name        = "allow_api_traffic"
+  description = "This rule blocks all traffic unless it is HTTPS for the eligibility screener"
+  vpc_id      = module.constants.vpc_id
+
+  # This is for testing purposes ONLY
+  ingress {
+    description     = "Limit traffic to just the screener"
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [data.aws_security_group.allow-lb-traffic.id]
+  }
+
+  egress {
+    description      = "allow all outbound traffic"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_cloudwatch_log_group" "mock_api" {
+  name = "mock-api"
+}
+resource "aws_ecs_task_definition" "mock-api-ecs-task-definition" {
+  family                   = "${var.environment_name}-api-task-definition"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  memory                   = "1024"
+  cpu                      = "512"
+  execution_role_arn       = "arn:aws:iam::546642427916:role/wic-mt-task-executor"
+  container_definitions = jsonencode([
+    {
+      name      = "${local.container_name}"
+      image     = "546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest-${var.environment_name}"
+      memory    = 1024
+      cpu       = 512
+      essential = true
+      portMappings = [
+        {
+          containerPort : 8080
+        }
+      ]
+      readonlyRootFilesystem = true
+      linuxParameters = {
+        capabilities = {
+          drop = ["ALL"]
+        },
+        initProcessEnabled = true
+      }
+      environment : [
+        {
+          "name" : "ENVIRONMENT"
+          "value" : "${var.environment_name}"
+        },
+        {
+          "name" : "POSTGRES_USER"
+          "value" : "${data.aws_ssm_parameter.db_username.value}"
+        },
+        {
+          "name" : "POSTGRES_PASSWORD"
+          "value" : "${aws_ssm_parameter.random_db_password.value}"
+        },
+        {
+          "name" : "POSTGRES_DB"
+          "value" : "${aws_db_instance.mock_api_db.name}"
+        },
+        {
+          "name" : "DB_HOST"
+          "value" : "${aws_db_instance.mock_api_db.address}"
+        },
+        {
+          "name" : "API_AUTH_TOKEN"
+          "value" : "${aws_ssm_parameter.random_api_key.value}"
+        },
+        {
+          "name" : "LOG_FORMAT"
+          "value" : "json"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-group"         = "${data.aws_cloudwatch_log_group.mock_api.name}",
+          "awslogs-region"        = "us-east-1",
+          "awslogs-stream-prefix" = "mock-api"
+        }
+      }
+    }
+  ])
+}
+# ------------------------------------------------------------------------------
+#    ECS task to Handle CSVs
+#
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "task_assume_role_policy" {
+  statement {
+    sid = "ECSTaskExecution"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+resource "aws_iam_role" "handle-csv" {
+  name               = "handle-csv-role"
+  description        = "allows an ECS task to generate CSVs and manage their storage"
+  assume_role_policy = data.aws_iam_policy_document.task_assume_role_policy.json
+}
+resource "aws_iam_role_policy_attachment" "handle-csv" {
+  policy_arn = aws_iam_policy.handle-csv.arn
+  role       = aws_iam_role.handle-csv.name
+}
+resource "aws_iam_policy" "handle-csv" {
+  name   = "handle-csv"
+  policy = data.aws_iam_policy_document.handle-csv.json
+}
+data "aws_iam_policy_document" "handle-csv" {
+  statement {
+    sid    = "AllowListBucket"
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:PutObject"
+    ]
+    resources = ["${aws_s3_bucket.wic-mt-csv-files.arn}", "${aws_s3_bucket.wic-mt-csv-files.arn}/*"]
+  }
+}
+
+resource "aws_security_group" "handle-csv" {
+  description = "allows connections for the csv generation ecs task"
+  name        = "ecs-task-security-group"
+  vpc_id      = module.constants.vpc_id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.allow-api-traffic.id}"]
+  }
+  egress {
+    description      = "allow all outbound traffic"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+resource "aws_ecs_task_definition" "handle-csv" {
+  family                   = "${var.environment_name}-csv-handler-definition"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  memory                   = "1024"
+  cpu                      = "512"
+  task_role_arn            = aws_iam_role.handle-csv.arn
+  execution_role_arn       = "arn:aws:iam::546642427916:role/wic-mt-task-executor"
+  container_definitions = jsonencode([
+    {
+      name      = "${var.environment_name}-mock-api-container"
+      image     = "546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest-${var.environment_name}"
+      memory    = 1024
+      cpu       = 512
+      essential = true
+      command   = ["poetry", "run", "create-eligibility-screener-csv"]
+      portMappings = [
+        {
+          containerPort : 8080
+        }
+      ]
+      linuxParameters = {
+        capabilities = {
+          drop = ["ALL"]
+        },
+        initProcessEnabled = true
+      }
+      environment : [
+        {
+          "name" : "ENVIRONMENT"
+          "value" : "${var.environment_name}"
+        },
+        {
+          "name" : "POSTGRES_USER"
+          "value" : "${data.aws_ssm_parameter.db_username.value}"
+        },
+        {
+          "name" : "POSTGRES_PASSWORD"
+          "value" : "${aws_ssm_parameter.random_db_password.value}"
+        },
+        {
+          "name" : "POSTGRES_DB"
+          "value" : "${aws_db_instance.mock_api_db.name}"
+        },
+        {
+          "name" : "DB_HOST"
+          "value" : "${aws_db_instance.mock_api_db.address}"
+        },
+        {
+          "name" : "LOG_FORMAT"
+          "value" : "json"
+        },
+        {
+          "name" : "ELIGIBILITY_SCREENER_CSV_OUTPUT_PATH"
+          "value" : "s3://${aws_s3_bucket.wic-mt-csv-files.id}"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-group"         = "mock-api",
+          "awslogs-region"        = "us-east-1",
+          "awslogs-stream-prefix" = "csv-handler"
+        }
+      }
+    }
+  ])
+}

--- a/infra/mock_api/template/main.tf
+++ b/infra/mock_api/template/main.tf
@@ -1,0 +1,41 @@
+# this file should contain information about tf versions and required providers
+
+terraform {
+  required_version = "1.2.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16.0"
+    }
+  }
+}
+
+module "constants" {
+  source = "../constants"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "wic-mt"
+  default_tags {
+    tags = merge(
+      module.constants.api_tags, {
+        environment = var.environment_name
+    })
+  }
+}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+
+# define env vars here!
+
+# Things you need for each environment:
+# logging per env
+
+# may need to create these roles for auth
+# prod-wic-dev role
+# nonprod-wic-dev role

--- a/infra/mock_api/template/rds.tf
+++ b/infra/mock_api/template/rds.tf
@@ -1,0 +1,73 @@
+# generates a secure password randomly
+
+# when 176 is merged:
+# update: common/mock_api_db/POSTGRES_PASSWORD in actual parameter store to prevent conflicts
+# update: what the rds setup considers a password
+# update: add updated auth token to ecs task
+
+resource "random_password" "random_db_password" {
+  length           = 48
+  special          = true
+  min_special      = 6
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_ssm_parameter" "random_db_password" {
+  name  = "/common/mock_api_db/POSTGRES_PASSWORD"
+  type  = "SecureString"
+  value = random_password.random_db_password.result
+}
+
+# Creates an API key we can use to auth containers with
+resource "random_password" "random_api_key" {
+  length           = 16
+  special          = true
+  min_special      = 6
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+resource "aws_ssm_parameter" "random_api_key" {
+  name  = "/common/mock_api_db/API_AUTH_TOKEN"
+  type  = "SecureString"
+  value = random_password.random_api_key.result
+}
+resource "aws_security_group" "rds" {
+  description = "allows connections to RDS"
+  name        = "mock-api-${var.environment_name}-rds-instance"
+  vpc_id      = module.constants.vpc_id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.allow-api-traffic.id}", "${aws_security_group.handle-csv.id}"]
+  }
+  egress {
+    description      = "allow all outbound traffic"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_db_instance" "mock_api_db" {
+  identifier                      = "${var.environment_name}-wic-mt"
+  allocated_storage               = 20
+  engine                          = "postgres"
+  engine_version                  = "13.7"
+  instance_class                  = "db.t3.micro"
+  db_name                         = "main"
+  port                            = 5432
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+  apply_immediately               = true
+  deletion_protection             = true
+  storage_encrypted               = true
+  final_snapshot_identifier       = "${var.environment_name}-final"
+  vpc_security_group_ids          = ["${aws_security_group.rds.id}"]
+  username                        = data.aws_ssm_parameter.db_username.value
+  password                        = aws_ssm_parameter.random_db_password.value
+}

--- a/infra/mock_api/template/s3.tf
+++ b/infra/mock_api/template/s3.tf
@@ -1,0 +1,57 @@
+# bucket for generated csv files
+resource "aws_s3_bucket" "wic-mt-csv-files" {
+  bucket        = "${var.environment_name}-api-csv-bucket"
+  force_destroy = true
+}
+# encrypt data
+resource "aws_s3_bucket_server_side_encryption_configuration" "wic-mt-csv-files" {
+  bucket = aws_s3_bucket.wic-mt-csv-files.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# block public access
+resource "aws_s3_bucket_public_access_block" "wic-mt-csv-files" {
+  bucket = aws_s3_bucket.wic-mt-csv-files.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# create iam policy for bucket
+data "aws_iam_policy_document" "wic-mt-csv-files" {
+  statement {
+    sid    = "AllowListBucket"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:PutObject"
+    ]
+    resources = [aws_s3_bucket.wic-mt-csv-files.arn, "${aws_s3_bucket.wic-mt-csv-files.arn}/*"]
+  }
+}
+
+# add policy to bucket
+resource "aws_s3_bucket_policy" "wic-mt-csv-files" {
+  bucket = aws_s3_bucket.wic-mt-csv-files.id
+  policy = data.aws_iam_policy_document.wic-mt-csv-files.json
+}
+
+# enable bucket ownership controls: https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
+resource "aws_s3_bucket_ownership_controls" "wic-mt-csv-files" {
+  bucket = aws_s3_bucket.wic-mt-csv-files.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}

--- a/infra/mock_api/template/s3.tf
+++ b/infra/mock_api/template/s3.tf
@@ -1,11 +1,11 @@
 # bucket for generated csv files
-resource "aws_s3_bucket" "wic-mt-csv-files" {
+resource "aws_s3_bucket" "wic_mt_csv_files" {
   bucket        = "${var.environment_name}-api-csv-bucket"
   force_destroy = true
 }
 # encrypt data
-resource "aws_s3_bucket_server_side_encryption_configuration" "wic-mt-csv-files" {
-  bucket = aws_s3_bucket.wic-mt-csv-files.bucket
+resource "aws_s3_bucket_server_side_encryption_configuration" "wic_mt_csv_files" {
+  bucket = aws_s3_bucket.wic_mt_csv_files.bucket
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
@@ -14,8 +14,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "wic-mt-csv-files"
 }
 
 # block public access
-resource "aws_s3_bucket_public_access_block" "wic-mt-csv-files" {
-  bucket = aws_s3_bucket.wic-mt-csv-files.id
+resource "aws_s3_bucket_public_access_block" "wic_mt_csv_files" {
+  bucket = aws_s3_bucket.wic_mt_csv_files.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -24,7 +24,7 @@ resource "aws_s3_bucket_public_access_block" "wic-mt-csv-files" {
 }
 
 # create iam policy for bucket
-data "aws_iam_policy_document" "wic-mt-csv-files" {
+data "aws_iam_policy_document" "wic_mt_csv_files" {
   statement {
     sid    = "AllowListBucket"
     effect = "Allow"
@@ -38,19 +38,19 @@ data "aws_iam_policy_document" "wic-mt-csv-files" {
       "s3:ListBucket",
       "s3:PutObject"
     ]
-    resources = [aws_s3_bucket.wic-mt-csv-files.arn, "${aws_s3_bucket.wic-mt-csv-files.arn}/*"]
+    resources = [aws_s3_bucket.wic_mt_csv_files.arn, "${aws_s3_bucket.wic_mt_csv_files.arn}/*"]
   }
 }
 
 # add policy to bucket
-resource "aws_s3_bucket_policy" "wic-mt-csv-files" {
-  bucket = aws_s3_bucket.wic-mt-csv-files.id
-  policy = data.aws_iam_policy_document.wic-mt-csv-files.json
+resource "aws_s3_bucket_policy" "wic_mt_csv_files" {
+  bucket = aws_s3_bucket.wic_mt_csv_files.id
+  policy = data.aws_iam_policy_document.wic_mt_csv_files.json
 }
 
 # enable bucket ownership controls: https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
-resource "aws_s3_bucket_ownership_controls" "wic-mt-csv-files" {
-  bucket = aws_s3_bucket.wic-mt-csv-files.id
+resource "aws_s3_bucket_ownership_controls" "wic_mt_csv_files" {
+  bucket = aws_s3_bucket.wic_mt_csv_files.id
   rule {
     object_ownership = "BucketOwnerEnforced"
   }

--- a/infra/mock_api/template/variables.tf
+++ b/infra/mock_api/template/variables.tf
@@ -1,0 +1,14 @@
+variable "environment_name" {
+  description = "Name of the environment"
+  type        = string
+}
+
+# ---------------------------------------------------
+#
+#      Managed in AWS Parameter Store
+#
+# ----------------------------------------------------
+
+data "aws_ssm_parameter" "db_username" {
+  name = "/common/mock_api_db/POSTGRES_USER"
+}


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-77

## Changes
> infra/mock_apir path added with the infrastructure for the eligibility screener repo

## Context for reviewers
> TThe [Mock API](https://github.com/navapbc/wic-mt-demo-project-mock-api) could benefit from being treated as an atomic, separate standalone service that can talk to multiple services. Right now, the [terraform for the Mock API](https://github.com/navapbc/wic-mt-demo-project) is tracked in a separate repo alongside the eligibility screener. Let’s actually break that apart and package the infrastructure for the Mock API in the Mock API repo.

> This ticket should be a migration of the terraform out of the project repo and into the Mock API repo. The end result should be that we should be able to manage AWS via terraform for Mock API.

## Testing
N/A
